### PR TITLE
Remove empty syncs by calling room_messages instead to get a sync token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ pytest = { version = "^7.4.2", optional = true }
 pytest-asyncio = { version = "^0.21.1", optional = true }
 pytest-cov = { version = "^4.1.0", optional = true }
 pytest-mock = { version = "^3.11.1", optional = true }
+ipython = { version = "^8.17.2", optional = true }
 
 [tool.poetry.extras]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "docker"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "docker", "ipython"]
 
 
 [build-system]

--- a/taskiq_matrix/exceptions.py
+++ b/taskiq_matrix/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from nio import SyncError
 from taskiq.exceptions import (
     ResultBackendError,
@@ -66,3 +68,10 @@ class DeviceQueueRequiresDeviceLabel(TaskIQMatrixError, SendTaskError):
         super().__init__(
             f'Device queue task {task_id} is missing the device label. When Device queue is specified, the task must have a "device" label.'
         )
+
+
+class CheckpointGetOrInitError(TaskIQMatrixError):
+    """Error if get_or_init_checkpoint() fails."""
+
+    def __init__(self, queue: str):
+        super().__init__(f"Unable to get or init checkpoint for queue {queue}")

--- a/taskiq_matrix/filters.py
+++ b/taskiq_matrix/filters.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
-from nio import AsyncClient, SyncError
+from nio import AsyncClient, MessageDirection, SyncError
 
 EMPTY_FILTER = {
     "presence": {"limit": 0, "types": []},

--- a/taskiq_matrix/matrix_broker.py
+++ b/taskiq_matrix/matrix_broker.py
@@ -102,7 +102,6 @@ class MatrixBroker(AsyncBroker):
             "args": ["mutex"],
             "kwargs": {},
         }
-
         schedules = await self.mutex_queue.client.room_get_state_event(
             self.mutex_queue.room_id,
             SCHEDULE_STATE_TYPE,
@@ -194,6 +193,7 @@ class MatrixBroker(AsyncBroker):
 
         Will exit if the initial sync fails or the provided room is not found.
         """
+        self.logger.log("Starting up broker", "info")
         await super().startup()
 
         # create and initialize queues
@@ -214,6 +214,7 @@ class MatrixBroker(AsyncBroker):
         """
         Shuts down the broker.
         """
+        self.logger.log("Shutting down the broker", "info")
         await self.device_queue.shutdown()
         await self.broadcast_queue.shutdown()
         await self.mutex_queue.shutdown()

--- a/tests/queue/test_matrix_queue.py
+++ b/tests/queue/test_matrix_queue.py
@@ -90,7 +90,7 @@ async def test_matrix_queue_get_tasks_return_tasks():
             "taskiq_matrix.matrix_queue.run_sync_filter", new=AsyncMock()
         ) as mock_sync_filter:
             mock_sync_filter.return_value = {matrix_queue.room_id: test_task_list}
-            result = await matrix_queue.get_tasks()
+            result = await matrix_queue.get_tasks(timeout=0)
 
             # verify that the function returned the same tasks that were created locally
             for i in range(len(result)):
@@ -202,7 +202,7 @@ async def test_matrix_queue_get_unacked_tasks_mixed_tasks(test_matrix_broker):
 
     # verify that a list of size 1 is returned containing the only unacked
     # task that was sent to the queue
-    result = await matrix_queue.get_unacked_tasks()
+    result = await matrix_queue.get_unacked_tasks(timeout=0)
     assert isinstance(result[1], list)
     assert len(result[1]) == 1
     assert result[1][0].type == event3["msgtype"]
@@ -253,7 +253,7 @@ async def test_matrix_queue_get_unacked_tasks_only_acked_tasks(test_matrix_broke
     )
 
     # verify that a list of size 0 is returned
-    result = await matrix_queue.get_unacked_tasks()
+    result = await matrix_queue.get_unacked_tasks(timeout=0)
     assert isinstance(result[1], list)
     assert len(result[1]) == 0
 
@@ -303,7 +303,7 @@ async def test_matrix_queue_get_unacked_tasks_only_unacked_tasks(test_matrix_bro
 
     # verify that a list of size 2 is returned containing both of the unacked
     # tasks sent to the queue
-    result = await matrix_queue.get_unacked_tasks()
+    result = await matrix_queue.get_unacked_tasks(timeout=0)
     assert isinstance(result[1], list)
     assert len(result[1]) == 2
 


### PR DESCRIPTION
Move away from using empty filter calls to /sync to get the current sync token as calls to /sync take progressively longer as more events accumulate in the user's rooms